### PR TITLE
404 render must be called AFTER layout. The current values are wrong (la...

### DIFF
--- a/module/Application/src/Application/View/Listener.php
+++ b/module/Application/src/Application/View/Listener.php
@@ -40,8 +40,8 @@ class Listener implements ListenerAggregate
     public function attach(EventCollection $events)
     {
         $this->listeners[] = $events->attach('dispatch.error', array($this, 'renderError'));
-        $this->listeners[] = $events->attach('dispatch', array($this, 'render404'), -80);
-        $this->listeners[] = $events->attach('dispatch', array($this, 'renderLayout'), -1000);
+        $this->listeners[] = $events->attach('dispatch', array($this, 'render404'), -1000);
+        $this->listeners[] = $events->attach('dispatch', array($this, 'renderLayout'), -80);
     }
 
     public function detach(EventCollection $events)


### PR DESCRIPTION
...yout is never called), which in some weird situations may lead to $e->getResponse() return NULL.
