### PR TITLE
consolidated the bootstrap in its own file

### DIFF
--- a/public/bootstrap.php
+++ b/public/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+chdir(dirname(__DIR__));
+require_once 'vendor/ZendFramework/library/Zend/Loader/AutoloaderFactory.php';
+Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array()));
+
+$appConfig = include 'config/application.config.php';
+
+$listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
+$defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
+$defaultListeners->getConfigListener()->addConfigGlobPath('config/autoload/*.config.php');
+
+$moduleManager = new Zend\Module\Manager($appConfig['modules']);
+$moduleManager->events()->attachAggregate($defaultListeners);
+$moduleManager->loadModules();
+
+return new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->getMergedConfig());

--- a/public/index.php
+++ b/public/index.php
@@ -1,20 +1,7 @@
 <?php
-chdir(dirname(__DIR__));
-require_once 'vendor/ZendFramework/library/Zend/Loader/AutoloaderFactory.php';
-Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array()));
-
-$appConfig = include 'config/application.config.php';
-
-$listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
-$defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
-$defaultListeners->getConfigListener()->addConfigGlobPath('config/autoload/*.config.php');
-
-$moduleManager = new Zend\Module\Manager($appConfig['modules']);
-$moduleManager->events()->attachAggregate($defaultListeners);
-$moduleManager->loadModules();
 
 // Create application, bootstrap, and run
-$bootstrap   = new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->getMergedConfig());
-$application = new Zend\Mvc\Application;
+$bootstrap = include 'bootstrap.php';
+$application = new Zend\Mvc\Application();
 $bootstrap->bootstrap($application);
 $application->run()->send();


### PR DESCRIPTION
This PR would make it more easy for modules to have their "own" applications (thinking of CLI apps).

This would be useful in for instance MistDoctrine (https://github.com/mstaessen/zf2-doctrine) or SpiffyDoctrine (https://github.com/SpiffyJr/SpiffyDoctrine). A submodule cannot rely on the locations of files. In this way, only bootstrap.php has be present and the bootstrap can set up the (console) application. 
