### PR TITLE
Inject the PluginBroker into the ActionController for controller plugins

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -9,6 +9,11 @@ return array(
                 'error' => 'Application\Controller\ErrorController',
                 'view'  => 'Zend\View\PhpRenderer',
             ),
+            'Zend\Mvc\Controller\ActionController' => array(
+                'parameters' => array(
+                    'broker'       => 'Zend\Mvc\Controller\PluginBroker',
+                ),
+            ),
             'Zend\View\PhpRenderer' => array(
                 'parameters' => array(
                     'resolver' => 'Zend\View\TemplatePathStack',


### PR DESCRIPTION
Inject the PluginBroker into the ActionController so that we pick up any module's controller plugins that they have injected into it. By injecting into ActionController, all controllers that extend it will automatically pick up this injection without having to inject themselves which of course saves a lot of typing for developers and stops them wondering why a given plugin isn't working in a particular controller!
