### PR TITLE
Inject the plugin loader into Zend\Mvc\Controller\PluginBroker by default

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -9,11 +9,22 @@ return array(
                 'error' => 'Application\Controller\ErrorController',
                 'view'  => 'Zend\View\PhpRenderer',
             ),
+
+            // Inject the plugin broker for controller plugins into
+            // the action controller for use by all controllers that
+            // extend it.
             'Zend\Mvc\Controller\ActionController' => array(
                 'parameters' => array(
                     'broker'       => 'Zend\Mvc\Controller\PluginBroker',
                 ),
             ),
+            'Zend\Mvc\Controller\PluginBroker' => array(
+                'parameters' => array(
+                    'loader' => 'Zend\Mvc\Controller\PluginLoader',
+                ),
+            ),
+
+            // Setup the PhpRenderer
             'Zend\View\PhpRenderer' => array(
                 'parameters' => array(
                     'resolver' => 'Zend\View\TemplatePathStack',


### PR DESCRIPTION
Inject the plugin loader into Zend\Mvc\Controller\PluginBroker by default to simplify injecting controller plugins
