### PR TITLE
Typo in documentation for directory

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,1 +1,1 @@
-This `vendors/` directory is where third-party modules should be installed.
+This `vendor/` directory is where third-party modules should be installed.


### PR DESCRIPTION
`vendors` -> `vendor`
