### PR TITLE
Using getBasePath() instead of getBaseUrl() to determine the basePath

### DIFF
--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -74,7 +74,7 @@ class Module implements AutoloaderProvider
         $view->plugin('url')->setRouter($app->getRouter());
         $view->doctype()->setDoctype('HTML5');
 
-        $basePath = $app->getRequest()->getBaseUrl();
+        $basePath = $app->getRequest()->getBasePath();
         $view->plugin('basePath')->setBasePath($basePath);
 
         $this->view = $view;


### PR DESCRIPTION
In my webserver configuration the script name may not be omitted.
Accessing the ZendSkeletonApplication with `http://localhost/ZendSkeletonApplication/public/index.php/`
resulted in the `$basePath` variable in the `getView()` method of the Module.php beeing filled with `/ZendSkeletonApplication/public/index.php`.
