### PR TITLE
This alleviates the requirement that "." be on the include path. 

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,13 +1,16 @@
 <?php
 chdir(dirname(__DIR__));
-require_once (getenv('ZF2_PATH') ?: 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
+$appDirectory = dirname(__DIR__);
+require_once (getenv('ZF2_PATH') ?: $appDirectory . '/vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
 Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array()));
 
-$appConfig = include 'config/application.config.php';
+$appConfig = include $appDirectory . '/config/application.config.php';
 
 $listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
 $defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
-$defaultListeners->getConfigListener()->addConfigGlobPath('config/autoload/*.config.php');
+$defaultListeners->getConfigListener()->addConfigGlobPath($appDirectory . '/config/autoload/*.config.php');
+
+unset($appDirectory);
 
 $moduleManager = new Zend\Module\Manager($appConfig['modules']);
 $moduleManager->events()->attachAggregate($defaultListeners);
@@ -18,3 +21,4 @@ $bootstrap   = new Zend\Mvc\Bootstrap($defaultListeners->getConfigListener()->ge
 $application = new Zend\Mvc\Application;
 $bootstrap->bootstrap($application);
 $application->run()->send();
+


### PR DESCRIPTION
I was seeing APC errors without this change and we run PHP w/o "." on the include path.
