### PR TITLE
Removed redundant argument being passed

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,7 @@
 <?php
 chdir(dirname(__DIR__));
 require_once (getenv('ZF2_PATH') ?: 'vendor/ZendFramework/library') . '/Zend/Loader/AutoloaderFactory.php';
-Zend\Loader\AutoloaderFactory::factory(array('Zend\Loader\StandardAutoloader' => array()));
+Zend\Loader\AutoloaderFactory::factory();
 
 $appConfig = include 'config/application.config.php';
 


### PR DESCRIPTION
I've removed a redundant argument that got passed to Zend\Loader\AutoloaderFactory::factory(). It defaults to the same value that got passed.
