### PR TITLE
Using alias for routing

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -2,6 +2,11 @@
 return array(
     'di' => array(
         'instance' => array(
+            // You can specify aliases for controllers here, as the routeStack
+            // uses the DI container to instantiate controllers
+            'alias' => array(
+                'index' => 'Application\Controller\IndexController',
+            ),
 
             // Setup for controllers.
 
@@ -32,7 +37,7 @@ return array(
                                     'action'     => '[a-zA-Z][a-zA-Z0-9_-]*',
                                 ),
                                 'defaults' => array(
-                                    'controller' => 'Application\Controller\IndexController',
+                                    'controller' => 'index',
                                     'action'     => 'index',
                                 ),
                             ),


### PR DESCRIPTION
Added an alias "index" for Application\Controller\IndexController so the defined Http\Segment route works as expected. Before, URLs built with this route would not be matched because of the defined constraint and having the full qualified class name (with namespace) in the URL is not really clean. This is also more like the default route scheme of 1.x versions of Zend Framework.
