### PR TITLE
Fix for ZF2-243 ...

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -7,7 +7,8 @@ $appConfig = include 'config/application.config.php';
 
 $listenerOptions  = new Zend\Module\Listener\ListenerOptions($appConfig['module_listener_options']);
 $defaultListeners = new Zend\Module\Listener\DefaultListenerAggregate($listenerOptions);
-$defaultListeners->getConfigListener()->addConfigGlobPath("config/autoload/{,*.}{global,local}.config.php");
+$defaultListeners->getConfigListener()->addConfigGlobPath("config/autoload/*local.config.php");
+$defaultListeners->getConfigListener()->addConfigGlobPath("config/autoload/*global.config.php");
     
 
 $moduleManager = new Zend\Module\Manager($appConfig['modules']);


### PR DESCRIPTION
requires we remove dependency in glob_brace and its syntax.

Replaced the single pattern with multiple config listeners that collect global and local named configuration files
Pull request for ZF2 repository: https://github.com/zendframework/zf2/pull/980
