### PR TITLE
Removing unused stat call and reducing complexity of index.php

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,13 +4,10 @@ use Zend\ServiceManager\ServiceManager,
 
 chdir(dirname(__DIR__));
 
-if (!file_exists('vendor/autoload.php')) {
-    throw new RuntimeException('vendor/autoload.php could not be found. Did you run php composer.phar install?');
-    exit;
-}
-
 // Composer autoloading
-require_once('vendor/autoload.php');
+if (!include_once('vendor/autoload.php')) {
+    throw new RuntimeException('vendor/autoload.php could not be found. Did you run `php composer.phar install`?');
+}
 
 // Get application stack configuration
 $configuration = include 'config/application.config.php';


### PR DESCRIPTION
This PR avoids one stat call when an opcode cache is in place and simply avoids halting the program with a zero-valued exit code if some error handling is in place.
