### PR TITLE
Add missing "echo"

### DIFF
--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -32,7 +32,7 @@ switch ($this->reason) {
 
 <dl>
     <dt>Controller:</dt>
-    <dd><?php $this->escape($this->controller) ?>
+    <dd><?php echo $this->escape($this->controller) ?>
 <?php
 if (isset($this->controller_class) 
     && $this->controller_class


### PR DESCRIPTION
I added a missing "echo" to display the controller name in the "error/404.phtml" page
