### PR TITLE
add rewritebase to htaccess

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,4 +1,5 @@
 RewriteEngine On
+RewriteBase /
 RewriteCond %{REQUEST_FILENAME} -s [OR]
 RewriteCond %{REQUEST_FILENAME} -l [OR]
 RewriteCond %{REQUEST_FILENAME} -d


### PR DESCRIPTION
For some reason mod rewrite rules without rewritebase cause recursive internal rewrites and 500 error as result. 

Probably due to dynamic vhosts development config.
