### PR TITLE
Fix for init_autoloader.php when using composer autoloader

### DIFF
--- a/init_autoloader.php
+++ b/init_autoloader.php
@@ -33,7 +33,7 @@ if (getenv('ZF2_PATH')) {           // Support for ZF2_PATH environment variable
 
 if ($zf2Path) {
     if (isset($loader)) {
-        $loader->add('Zend', $zf2Path . '/');
+        $loader->add('Zend', $zf2Path);
     } else {
         include $zf2Path . '/Zend/Loader/AutoloaderFactory.php';
         Zend\Loader\AutoloaderFactory::factory(array(


### PR DESCRIPTION
Removed sub-directory /Zend from init_autoloader.php when using the ZF_PATH env var.    The extra /Zend was causing it to look for classes in $ZF_PATH.'/Zend/Zend/'
