### PR TITLE
Fix routing issue with '/' at end of url 

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -39,7 +39,7 @@ return array(
                     'default' => array(
                         'type'    => 'Segment',
                         'options' => array(
-                            'route'    => '/[:controller[/:action]]',
+                            'route'    => '/[:controller[/:action]][/]',
                             'constraints' => array(
                                 'controller' => '[a-zA-Z][a-zA-Z0-9_-]*',
                                 'action'     => '[a-zA-Z][a-zA-Z0-9_-]*',


### PR DESCRIPTION
Without this patch urls like this: http://localhost/application/index/index/  (with '/' at the end of route)  are incorrect. 
