### PR TITLE
Add Application namespace to composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "autoload": {
         "psr-0": {
-            "Application": "module/Application/src/"
+            "Application\\": "module/Application/src/"
         }
     },
     "require": {


### PR DESCRIPTION
As noted in the user guide, [Autoloading files](http://framework.zend.com/manual/2.0/en/user-guide/modules.html#autoloading-files), the `Application` namespace should be added to `composer.json` when using composer to install dependencies.
