### PR TITLE
Polyfill support for non-composer autoloading

### DIFF
--- a/init_autoloader.php
+++ b/init_autoloader.php
@@ -41,6 +41,8 @@ if ($zf2Path) {
                 'autoregister_zf' => true
             )
         ));
+        require $zf2Path . '/Zend/Stdlib/compatibility/autoload.php';
+        require $zf2Path . '/Zend/Session/compatibility/autoload.php';
     }
 }
 


### PR DESCRIPTION
This ensures that polyfill support for version-specific variants of classes works correctly when not using composer for autoloading. See zendframework/zf2#3714 for more details.
