### PR TITLE
Remove polyfill support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,6 @@
     "homepage": "http://framework.zend.com/",
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zendframework": "2.*"
+        "zendframework/zendframework": ">2.1.3"
     }
 }

--- a/init_autoloader.php
+++ b/init_autoloader.php
@@ -41,8 +41,6 @@ if ($zf2Path) {
                 'autoregister_zf' => true
             )
         ));
-        require $zf2Path . '/Zend/Stdlib/compatibility/autoload.php';
-        require $zf2Path . '/Zend/Session/compatibility/autoload.php';
     }
 }
 


### PR DESCRIPTION
Polyfill support is transparently handled within the framework starting with 2.1.4dev, and as such, does not require any manual loading of autoload support; in fact, the files previously referenced now trigger `E_USER_DEPRECATED` notices, making them undesirable.
