### PR TITLE
PHP 5.4+ built-in webserver support

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -5,6 +5,11 @@
  */
 chdir(dirname(__DIR__));
 
+// Decline static file requests back to the PHP built-in webserver
+if (php_sapi_name() === 'cli-server' && is_file(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) {
+    return false;
+}
+
 // Setup autoloading
 require 'init_autoloader.php';
 


### PR DESCRIPTION
Presently, the public/index.php entry point does not support the PHP built-in webserver properly.

When invoked without the index.php script as its router, the built-in webserver will intercept _any_ request for a route containing a '.' character.
Presently, this would interfere with controllers which pretend to be files (e.g. http://example.com/packages.json) by way of routing.

When invoked _with_ the index.php script as its router, the built-in webserver currently will not route _any_ requests for static files, unless you return false from the router script (called "declining a request").

The included patch adds logic to the index.php script which will check the request path to see if it coincides with an existent static file, in which case it will "decline" the request, passing the handling back to the built-in webserver to serve. This allows routing to happen for files which do not exist, which is consistent with other webservers.
