### PR TITLE
[2.2.1] Skeleton Application CLI not working out of the box

### DIFF
--- a/module/Application/src/Application/Controller/IndexController.php
+++ b/module/Application/src/Application/Controller/IndexController.php
@@ -9,7 +9,6 @@
 
 namespace Application\Controller;
 
-use Zend\Mvc\Application;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 


### PR DESCRIPTION
The CLI interface is broken after installation of the skeleton application with zendframework/zendframework 2.2.1.

These are the steps to reproduce the problem:

``` sh
git clone git://github.com/zendframework/ZendSkeletonApplication.git
cd ZendSkeletonApplication
./composer.phar self-update
./composer.phar update --prefer-source
cd vendor/zendframework/zendframework
git checkout release-2.2.1
cd ../../..
php public/index.php
```

The application will report

```
PHP Fatal error:  Uncaught exception 'Zend\Mvc\Router\Exception\RuntimeException' with message 'Given route does not implement Console route interface' in /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/zendframework/zendframework/library/Zend/Mvc/Router/Console/SimpleRouteStack.php:81
Stack trace:
#0 /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/zendframework/zendframework/library/Zend/Mvc/Router/Console/SimpleRouteStack.php(51): Zend\Mvc\Router\Console\SimpleRouteStack->routeFromArray(Array)
#1 /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/zendframework/zendframework/library/Zend/Mvc/Router/SimpleRouteStack.php(140): Zend\Mvc\Router\Console\SimpleRouteStack->addRoute('home', Array)
#2 /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/zendframework/zendframework/library/Zend/Mvc/Router/SimpleRouteStack.php(84): Zend\Mvc\Router\SimpleRouteStack->addRoutes(Array)
#3 [internal function]: Zend\Mvc\Router\SimpleRouteStack::factory(Array)
#4 /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/z in /home/ocramius/Desktop/t/ZendSkeletonApplication/vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php on line 860
```
