### PR TITLE
Wrong order of config/autoload

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -20,7 +20,8 @@ return array(
         // modules are loaded. These effectively overide configuration
         // provided by modules themselves. Paths may use GLOB_BRACE notation.
         'config_glob_paths' => array(
-            'config/autoload/{,*.}{global,local}.php',
+            'config/autoload/{,*.}global.php',
+            'config/autoload/{,*.}local.php',
         ),
 
         // Whether or not to enable a configuration cache.

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -20,8 +20,7 @@ return array(
         // modules are loaded. These effectively overide configuration
         // provided by modules themselves. Paths may use GLOB_BRACE notation.
         'config_glob_paths' => array(
-            'config/autoload/{,*.}global.php',
-            'config/autoload/{,*.}local.php',
+            'config/autoload/{{,*.}global,{,*.}local}.php',
         ),
 
         // Whether or not to enable a configuration cache.


### PR DESCRIPTION
Configuration must load in that order:

 * global.php
 * \*.global.php
 * local.php
 * \*.local.php

But in fact, it is not. I am create gist, to prove it https://gist.github.com/ftdebugger/5934533. Here the result:

```
Array
(
    [0] => config/autoload/global.php
    [1] => config/autoload/local.php
    [2] => config/autoload/some.global.php
    [3] => config/autoload/some.local.php
)
```

Loading configuration in two steps guaranteed needed order