### PR TITLE
Adding 'hello world' Behat test as a small example of BDD integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ nbproject
 .settings
 composer.lock
 vendor/bin
+vendor

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,5 @@
+default:
+  extensions:
+    Behat\MinkExtension\Extension:
+      base_url: localhost
+      goutte: ~

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
         "zendframework/zendframework": ">2.2.0rc1"
     },
     "require-dev": {
-        "behat/behat": "2.4.*"
+        "behat/behat": "~2.4",
+        "behat/mink-extension":"~1.2",
+        "behat/mink-goutte-driver": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,8 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zendframework": ">2.2.0rc1"
+    },
+    "require-dev": {
+        "behat/behat": "2.4.*"
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,51 +1,26 @@
 <?php
 
+use Behat\Behat\Context\ClosuredContextInterface;
+use Behat\Behat\Context\TranslatedContextInterface;
 use Behat\Behat\Context\BehatContext;
+use Behat\Behat\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\MinkExtension\Context\MinkContext;
 
 /**
  * Features context.
  */
-class FeatureContext extends BehatContext
+class FeatureContext extends MinkContext
 {
-    protected $path = '';
-
-    protected $page = '';
-
     /**
      * Initializes context.
      * Every scenario gets it's own context object.
      *
-     * @param array $parameters context parameters (set them up through behat.yml)
+     * @param array $parameters context parameters (set them up through behat.yml.dist)
      */
     public function __construct(array $parameters)
     {
         // Initialize your context here
-    }
-
-    /**
-     * @Given /^I am in path "([^"]*)"$/
-     */
-    public function iAmInPath($path)
-    {
-        $this->path = 'http://localhost:8888' . $path;
-    }
-
-    /**
-     * @When /^I load the page$/
-     */
-    public function iLoadThePage()
-    {
-        $this->page = file_get_contents($this->path);
-    }
-
-    /**
-     * @Then /^I should see:$/
-     */
-    public function iShouldSee(PyStringNode $string)
-    {
-        if (! strpos($this->page, (string) $string)) {
-            throw new Exception("Actual page is:\n" . $this->page);
-        }
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,0 +1,51 @@
+<?php
+
+use Behat\Behat\Context\BehatContext;
+use Behat\Gherkin\Node\PyStringNode;
+
+/**
+ * Features context.
+ */
+class FeatureContext extends BehatContext
+{
+    protected $path = '';
+
+    protected $page = '';
+
+    /**
+     * Initializes context.
+     * Every scenario gets it's own context object.
+     *
+     * @param array $parameters context parameters (set them up through behat.yml)
+     */
+    public function __construct(array $parameters)
+    {
+        // Initialize your context here
+    }
+
+    /**
+     * @Given /^I am in path "([^"]*)"$/
+     */
+    public function iAmInPath($path)
+    {
+        $this->path = 'http://localhost:8888' . $path;
+    }
+
+    /**
+     * @When /^I load the page$/
+     */
+    public function iLoadThePage()
+    {
+        $this->page = file_get_contents($this->path);
+    }
+
+    /**
+     * @Then /^I should see:$/
+     */
+    public function iShouldSee(PyStringNode $string)
+    {
+        if (! strpos($this->page, (string) $string)) {
+            throw new Exception("Actual page is:\n" . $this->page);
+        }
+    }
+}

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -4,9 +4,6 @@ Feature: Application Index
   I need to be able to load the application homepage
 
 Scenario: Load the homepage
-  Given I am in path "/"
-  When I load the page
-  Then I should see:
-    """
-    Welcome to <span class="zf-green">Zend Framework 2</span>
-    """
+  Given I am on the homepage
+  Then the response status code should be 200
+  And I should see "Welcome to Zend Framework 2"

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -1,0 +1,12 @@
+Feature: Application Index
+  In order to see the application index
+  As an anonymous user
+  I need to be able to load the application homepage
+
+Scenario: Load the homepage
+  Given I am in path "/"
+  When I load the page
+  Then I should see:
+    """
+    Welcome to <span class="zf-green">Zend Framework 2</span>
+    """


### PR DESCRIPTION
 > **tl;dr**: ZF is one of the leading portions of the PHP community, and should encourage testing and doing it correctly. We should show users where to do integration testing, and where unit testing.

A simple behat integration to encourage BDD for the skeleton application.

This is just a WIP since I myself am new to all this. The diff is minimal just to show the concept behind this, and this PR is not meant to be merged.

I strongly believe the end user of the skeleton application should be well aware of the separation that has to be done between end-to-end integration testing (this kind) and unit testing (for module code).

Providing a `make test` similar setup would be a benefit.

I'm hereby proposing to ship unit tests with the modules (`Application` module as a start) and this thing with the `ZendSkeletonApplication`.

The other discussion thread is at http://zend-framework-community.634137.n4.nabble.com/Including-BDD-TDD-in-the-skeleton-td4660628.html

NOTE: Yes, the code is wrong. There's already plugins for Behat that allow us to run this sort of HTTP requests, check content, verify links, etc etc. That's not the point of this pull request.