### PR TITLE
Fixed configuration example

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -15,10 +15,12 @@ return array(
     // Whether or not to enable a configuration cache.
     // If enabled, the merged configuration will be cached and used in
     // subsequent requests.
-    //'config_cache_enabled' => false,
-    // The key used to create the configuration cache file name.
-    //'config_cache_key' => 'module_config_cache',
-    // The path in which to cache merged configuration.
-    //'cache_dir' =>  './data/cache',
-    // ...
+    //'module_listener_options' => array(
+    //    'config_cache_enabled' => false,
+    //    // The key used to create the configuration cache file name.
+    //    'config_cache_key' => 'module_config_cache',
+    //    // The path in which to cache merged configuration.
+    //    'cache_dir' =>  './data/cache',
+    //    ...
+    // )
 );


### PR DESCRIPTION
The example was missing out the `module_listener_options` array and therefore the example-configuration would not have worked. That's fixed now
