### PR TITLE
Please add zend brand logos in navbar

### DIFF
--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -34,7 +34,7 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <a class="navbar-brand" href="<?php echo $this->url('home') ?>"><?php echo $this->translate('Skeleton Application') ?></a>
+                    <a class="navbar-brand" href="<?php echo $this->url('home') ?>"><img src="<?php echo $this->basePath('img/zf2-logo.png') ?>" alt="Zend Framework 2"/>&nbsp;<?php echo $this->translate('Skeleton Application') ?></a>
                 </div>
                 <div class="collapse navbar-collapse">
                     <ul class="nav navbar-nav">


### PR DESCRIPTION
This probably is not important, 
but it would be better if the navbar brand the zend logo is also added 
as the previous version twitter bootstrap version 2 ago :)
So branding zand framework will be remain
although only a beginning skeleton, but it's the first thing people see, Hhhee

old version
![zf2 skeleton application 2013-09-05 15-40-46](https://f.cloud.github.com/assets/4241620/1086829/fe1e9eba-1607-11e3-95ef-37ed03c9065e.png)

current version
![zf2 skeleton application 2013-09-05 15-41-31](https://f.cloud.github.com/assets/4241620/1086831/0c302226-1608-11e3-8586-9cc1407378ad.png)

Just a suggestion :D
