### PR TITLE
Remove module_listener_options since autoloaded config don't apply

### DIFF
--- a/config/autoload/local.php.dist
+++ b/config/autoload/local.php.dist
@@ -12,15 +12,4 @@
  */
 
 return array(
-    // Whether or not to enable a configuration cache.
-    // If enabled, the merged configuration will be cached and used in
-    // subsequent requests.
-    //'module_listener_options' => array(
-    //    'config_cache_enabled' => false,
-    //    // The key used to create the configuration cache file name.
-    //    'config_cache_key' => 'module_config_cache',
-    //    // The path in which to cache merged configuration.
-    //    'cache_dir' =>  './data/cache',
-    //    ...
-    // )
 );


### PR DESCRIPTION
it's been a while since #170, and the stub is still misleading for new people.
