### PR TITLE
Default error page possible XSS

### DIFF
--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -14,11 +14,11 @@
     </dd>
     <dt><?php echo $this->translate('Message') ?>:</dt>
     <dd>
-        <pre class="prettyprint linenums"><?php echo $this->exception->getMessage() ?></pre>
+        <pre class="prettyprint linenums"><?php echo $this->escapeHtml($this->exception->getMessage()) ?></pre>
     </dd>
     <dt><?php echo $this->translate('Stack trace') ?>:</dt>
     <dd>
-        <pre class="prettyprint linenums"><?php echo $this->exception->getTraceAsString() ?></pre>
+        <pre class="prettyprint linenums"><?php echo $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
     </dd>
 </dl>
 <?php
@@ -38,11 +38,11 @@
             </dd>
             <dt><?php echo $this->translate('Message') ?>:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?php echo $e->getMessage() ?></pre>
+                <pre class="prettyprint linenums"><?php echo $this->escapeHtml($e->getMessage()) ?></pre>
             </dd>
             <dt><?php echo $this->translate('Stack trace') ?>:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?php echo $e->getTraceAsString() ?></pre>
+                <pre class="prettyprint linenums"><?php echo $this->escapeHtml($e->getTraceAsString()) ?></pre>
             </dd>
         </dl>
     </li>


### PR DESCRIPTION
Hello!

The default error page:
module/Application/view/error/index.phtml
is vulnerable to Cross-Site-Scripting issues, if the exception message (and to a limited extend also a string parameter in the call-stack) contains user supplied input.
All outputs of "getMessage()" and "getTraceAsString()" should be guarded by "$this->escapeHtml(...)".
Affected are the lines 17, 21, 41 & 45.

Best regards,

Das
