### PR TITLE
README - No need to move to public directory to use PHP CLI Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Web Server Setup
 
 The simplest way to get started if you are using PHP 5.4 or above is to start the internal PHP cli-server in the root directory:
 
-    cd public
     php -S 0.0.0.0:8080 -t public/ public/index.php
 
 This will start the cli-server on port 8080, and bind it to all network


### PR DESCRIPTION
This will fail:

```
cd public
php -S 0.0.0.0:8080 -t public/ public/index.php
```
