### PR TITLE
Centralize .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ nbproject
 .project
 .settings
 composer.lock
-vendor/bin
+vendor/
+data/cache/
+!data/cache/.gitkeep
+config/autoload/local.php
+config/autoload/*.local.php

--- a/config/autoload/.gitignore
+++ b/config/autoload/.gitignore
@@ -1,2 +1,0 @@
-local.php
-*.local.php

--- a/data/cache/.gitignore
+++ b/data/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
Seem to me that having all the `.gitignore` stuff in one place alo https://github.com/zfcampus/zf-apigility-skeleton/commit/d804ae2f4c4cba9eba477528018b9826f6300834 increase the  readability.