### PR TITLE
Updated php minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "homepage": "http://framework.zend.com/",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.23",
         "zendframework/zendframework": "2.3.*"
     }
 }


### PR DESCRIPTION
If using zendframework 2.3 in the composer definition, the minimum php version must be 5.3.23. I think this should be set in this composer file as well, as you can not use the ZendSkeletonApplication without the zendframework package.
