### PR TITLE
move class_exists(ZendLoaderAutoloaderFactory) before $zf2Path check based on #248

### DIFF
--- a/init_autoloader.php
+++ b/init_autoloader.php
@@ -49,7 +49,6 @@ if ($zf2Path) {
     }
 }
 
-
 if (!class_exists('Zend\Loader\AutoloaderFactory')) {
     throw new RuntimeException('Unable to load ZF2. Run `php composer.phar install` or define a ZF2_PATH environment variable.');
 }


### PR DESCRIPTION
based on #248 , I think the class_exist for Zend\Loader\AutoloaderFactory check can be moved before vendor/ZF2/library check
