### PR TITLE
Hotfix/end loops exception

### DIFF
--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -93,6 +93,14 @@ if (isset($this->controller_class)
     </li>
     <?php
         $e = $e->getPrevious();
+	    if (!isset($icount)) {
+			$icount = 0;
+		} else {
+			$icount += 1;
+			if ($icount >=10) {
+				break;
+			}
+		}
         endwhile;
     ?>
 </ul>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -93,14 +93,14 @@ if (isset($this->controller_class)
     </li>
     <?php
         $e = $e->getPrevious();
-	    if (!isset($icount)) {
-			$icount = 0;
-		} else {
-			$icount += 1;
-			if ($icount >=10) {
-				break;
-			}
-		}
+        if (!isset($icount)) {
+            $icount = 0;
+        } else {
+            $icount += 1;
+            if ($icount >=10) {
+                break;
+            }
+        }
         endwhile;
     ?>
 </ul>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -68,6 +68,7 @@ if (isset($this->controller_class)
 </dl>
 <?php
     $e = $this->exception->getPrevious();
+    $icount = 0;
     if ($e) :
 ?>
 <hr/>
@@ -93,13 +94,10 @@ if (isset($this->controller_class)
     </li>
     <?php
         $e = $e->getPrevious();
-        if (!isset($icount)) {
-            $icount = 0;
-        } else {
-            $icount += 1;
-            if ($icount >=10) {
-                break;
-            }
+        $icount += 1;
+        if ($icount >=10) {
+            echo "There may be more than Ten exceptions, but we have no enough memory to proccess it.";
+            break;
         }
         endwhile;
     ?>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -95,8 +95,8 @@ if (isset($this->controller_class)
     <?php
         $e = $e->getPrevious();
         $icount += 1;
-        if ($icount >=10) {
-            echo "There may be more than Ten exceptions, but we have no enough memory to proccess it.";
+        if ($icount >=50) {
+            echo "<li>There may be more exceptions, but we have no enough memory to proccess it.</li>";
             break;
         }
         endwhile;

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -48,6 +48,15 @@
     </li>
     <?php
         $e = $e->getPrevious();
+        if (!isset($icount)) {
+			$icount = 0;
+		} else {
+			$icount += 1;
+			if ($icount >=10) {
+				break;
+			}
+		}
+
         endwhile;
     ?>
 </ul>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -49,13 +49,13 @@
     <?php
         $e = $e->getPrevious();
         if (!isset($icount)) {
-			$icount = 0;
-		} else {
-			$icount += 1;
-			if ($icount >=10) {
-				break;
-			}
-		}
+            $icount = 0;
+        } else {
+            $icount += 1;
+            if ($icount >=10) {
+                break;
+            }
+        }
 
         endwhile;
     ?>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -23,6 +23,7 @@
 </dl>
 <?php
     $e = $this->exception->getPrevious();
+    $icount = 0;
     if ($e) :
 ?>
 <hr/>
@@ -48,15 +49,11 @@
     </li>
     <?php
         $e = $e->getPrevious();
-        if (!isset($icount)) {
-            $icount = 0;
-        } else {
-            $icount += 1;
-            if ($icount >=10) {
-                break;
-            }
+        $icount += 1;
+        if ($icount >= 50) {
+            echo "<li>There may be more exceptions, but we have no enough memory to proccess it.</li>";
+            break;
         }
-
         endwhile;
     ?>
 </ul>


### PR DESCRIPTION
The exception dump loops should be end at some where, or your memory should be not enough to handle the request.