### PR TITLE
Updated composer.json with correct version of php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "homepage": "http://framework.zend.com/",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.23",
         "zendframework/zendframework": "2.3.*"
     }
 }


### PR DESCRIPTION
Resolved conflict between ZF2 version and PHP version. 
ZF2 2.3.\* depends on php 5.2.23 or higher as described in http://framework.zend.com/blog/zend-framework-2-3-0-released.html
