### PR TITLE
Vagrant box changed from chef/ubuntu-14.04 to bento/ubuntu-14.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ echo "** [ZEND] Visit http://localhost:8085 in your browser for to view the appl
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'chef/ubuntu-14.04'
+  config.vm.box = 'bento/ubuntu-14.04'
   config.vm.network "forwarded_port", guest: 80, host: 8085
   config.vm.hostname = "skeleton-zf.local"
   config.vm.synced_folder '.', '/var/www/zf'


### PR DESCRIPTION
Today I have tried to run vagrant up in a new project and the box 'chef/ubuntu-14.04' was not found.

If you check the link https://atlas.hashicorp.com/chef/  it says:

"If you are looking for Bento boxes they now have their own organization https://atlas.hashicorp.com/bento/"

This pull request changes the box to 'bento/ubuntu-14.04'.