### PR TITLE
Added additional instanceof checks for Error types

### DIFF
--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -48,7 +48,7 @@ if (isset($this->controller_class)
 
 <?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
 
-<?php if(isset($this->exception) && $this->exception instanceof Exception): ?>
+<?php if(isset($this->exception) && ($this->exception instanceof Exception || $this->exception instanceof Error)): ?>
 <hr/>
 <h2>Additional information:</h2>
 <h3><?php echo get_class($this->exception); ?></h3>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -3,7 +3,7 @@
 
 <?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
 
-<?php if(isset($this->exception) && $this->exception instanceof Exception): ?>
+<?php if(isset($this->exception) && ($this->exception instanceof Exception || $this->exception instanceof Error)): ?>
 <hr/>
 <h2>Additional information:</h2>
 <h3><?php echo get_class($this->exception); ?></h3>


### PR DESCRIPTION
Since zend-mvc 3.0 will catch any Throwable when under PHP 7, we need to test for either `Exception` or `Error` in the error handling view scripts.

See https://github.com/zendframework/zend-mvc/issues/157#issuecomment-224987189 for an example of why this is needed.