### PR TITLE
Error views updated

### DIFF
--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -1,7 +1,7 @@
 <h1>A 404 error occurred</h1>
 <h2><?= $this->message ?></h2>
 
-<?php if (!empty($this->reason)): ?>
+<?php if (!empty($this->reason)) : ?>
     <?php
     switch ($this->reason) {
         case \Zend\Mvc\Application::ERROR_CONTROLLER_CANNOT_DISPATCH:
@@ -27,7 +27,7 @@
     <p><?= $reasonMessage ?></p>
 <?php endif ?>
 
-<?php if (isset($this->controller) && $this->controller): ?>
+<?php if (isset($this->controller) && $this->controller) : ?>
     <dl>
         <dt>Controller:</dt>
         <dd>
@@ -44,8 +44,8 @@
     </dl>
 <?php endif ?>
 
-<?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
-    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)): ?>
+<?php if (isset($this->display_exceptions) && $this->display_exceptions) : ?>
+    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
         <hr/>
 
         <h2>Additional information:</h2>
@@ -65,13 +65,13 @@
             </dd>
         </dl>
 
-        <?php if ($ex = $this->exception->getPrevious()): ?>
+        <?php if ($ex = $this->exception->getPrevious()) : ?>
             <hr/>
 
             <h2>Previous exceptions:</h2>
             <ul class="list-unstyled">
                 <?php $icount = 0; ?>
-                <?php while ($ex): ?>
+                <?php while ($ex) : ?>
                     <li>
                         <h3><?= get_class($ex) ?></h3>
                         <dl>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -1,5 +1,5 @@
 <h1>A 404 error occurred</h1>
-<h2><?php echo $this->message ?></h2>
+<h2><?= $this->message ?></h2>
 
 <?php if (!empty($this->reason)): ?>
     <?php
@@ -24,16 +24,15 @@
             break;
     }
     ?>
-    <p><?php echo $reasonMessage ?></p>
+    <p><?= $reasonMessage ?></p>
 <?php endif ?>
 
 <?php if (isset($this->controller) && $this->controller): ?>
     <dl>
         <dt>Controller:</dt>
         <dd>
+            <?= $this->escapeHtml($this->controller) ?>
             <?php
-            echo $this->escapeHtml($this->controller);
-
             if (isset($this->controller_class)
                 && $this->controller_class
                 && $this->controller_class != $this->controller
@@ -50,19 +49,19 @@
         <hr/>
 
         <h2>Additional information:</h2>
-        <h3><?php echo get_class($this->exception) ?></h3>
+        <h3><?= get_class($this->exception) ?></h3>
         <dl>
             <dt>File:</dt>
             <dd>
-                <pre><?php echo $this->exception->getFile() ?>:<?php echo $this->exception->getLine() ?></pre>
+                <pre><?= $this->exception->getFile() ?>:<?= $this->exception->getLine() ?></pre>
             </dd>
             <dt>Message:</dt>
             <dd>
-                <pre><?php echo $this->escapeHtml($this->exception->getMessage()) ?></pre>
+                <pre><?= $this->escapeHtml($this->exception->getMessage()) ?></pre>
             </dd>
             <dt>Stack trace:</dt>
             <dd>
-                <pre><?php echo $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
+                <pre><?= $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
             </dd>
         </dl>
 
@@ -74,19 +73,19 @@
                 <?php $icount = 0; ?>
                 <?php while ($ex): ?>
                     <li>
-                        <h3><?php echo get_class($ex) ?></h3>
+                        <h3><?= get_class($ex) ?></h3>
                         <dl>
                             <dt>File:</dt>
                             <dd>
-                                <pre><?php echo $ex->getFile() ?>:<?php echo $ex->getLine() ?></pre>
+                                <pre><?= $ex->getFile() ?>:<?= $ex->getLine() ?></pre>
                             </dd>
                             <dt>Message:</dt>
                             <dd>
-                                <pre><?php echo $this->escapeHtml($ex->getMessage()) ?></pre>
+                                <pre><?= $this->escapeHtml($ex->getMessage()) ?></pre>
                             </dd>
                             <dt>Stack trace:</dt>
                             <dd>
-                                <pre><?php echo $this->escapeHtml($ex->getTraceAsString()) ?></pre>
+                                <pre><?= $this->escapeHtml($ex->getTraceAsString()) ?></pre>
                             </dd>
                         </dl>
                     </li>

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -1,113 +1,106 @@
 <h1>A 404 error occurred</h1>
-<h2><?= $this->message ?></h2>
+<h2><?php echo $this->message ?></h2>
 
-<?php if (isset($this->reason) && $this->reason): ?>
-
-<?php
-$reasonMessage= '';
-switch ($this->reason) {
-    case 'error-controller-cannot-dispatch':
-        $reasonMessage = 'The requested controller was unable to dispatch the request.';
-        break;
-    case 'error-controller-not-found':
-        $reasonMessage = 'The requested controller could not be mapped to an existing controller class.';
-        break;
-    case 'error-controller-invalid':
-        $reasonMessage = 'The requested controller was not dispatchable.';
-        break;
-    case 'error-router-no-match':
-        $reasonMessage = 'The requested URL could not be matched by routing.';
-        break;
-    default:
-        $reasonMessage = 'We cannot determine at this time why a 404 was generated.';
-        break;
-}
-?>
-
-<p><?= $reasonMessage ?></p>
-
+<?php if (!empty($this->reason)): ?>
+    <?php
+    switch ($this->reason) {
+        case \Zend\Mvc\Application::ERROR_CONTROLLER_CANNOT_DISPATCH:
+            $reasonMessage = 'The requested controller was unable to dispatch the request.';
+            break;
+        case \Zend\Mvc\Application::ERROR_MIDDLEWARE_CANNOT_DISPATCH:
+            $reasonMessage = 'The requested middleware was unable to dispatch the request.';
+            break;
+        case \Zend\Mvc\Application::ERROR_CONTROLLER_NOT_FOUND:
+            $reasonMessage = 'The requested controller could not be mapped to an existing controller class.';
+            break;
+        case \Zend\Mvc\Application::ERROR_CONTROLLER_INVALID:
+            $reasonMessage = 'The requested controller was not dispatchable.';
+            break;
+        case \Zend\Mvc\Application::ERROR_ROUTER_NO_MATCH:
+            $reasonMessage = 'The requested URL could not be matched by routing.';
+            break;
+        default:
+            $reasonMessage = 'We cannot determine at this time why a 404 was generated.';
+            break;
+    }
+    ?>
+    <p><?php echo $reasonMessage ?></p>
 <?php endif ?>
 
 <?php if (isset($this->controller) && $this->controller): ?>
+    <dl>
+        <dt>Controller:</dt>
+        <dd>
+            <?php
+            echo $this->escapeHtml($this->controller);
 
-<dl>
-    <dt>Controller:</dt>
-    <dd><?= $this->escapeHtml($this->controller) ?>
-<?php
-if (isset($this->controller_class)
-    && $this->controller_class
-    && $this->controller_class != $this->controller
-) {
-    echo '(' . sprintf('resolves to %s', $this->escapeHtml($this->controller_class)) . ')';
-}
-?>
-</dd>
-</dl>
-
+            if (isset($this->controller_class)
+                && $this->controller_class
+                && $this->controller_class != $this->controller
+            ) {
+                echo '(' . sprintf('resolves to %s', $this->escapeHtml($this->controller_class)) . ')';
+            }
+            ?>
+        </dd>
+    </dl>
 <?php endif ?>
 
 <?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
+    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)): ?>
+        <hr/>
 
-<?php if(isset($this->exception) && ($this->exception instanceof Exception || $this->exception instanceof Error)): ?>
-<hr/>
-<h2>Additional information:</h2>
-<h3><?= get_class($this->exception) ?></h3>
-<dl>
-    <dt>File:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->exception->getFile() ?>:<?= $this->exception->getLine() ?></pre>
-    </dd>
-    <dt>Message:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->exception->getMessage() ?></pre>
-    </dd>
-    <dt>Stack trace:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->exception->getTraceAsString() ?></pre>
-    </dd>
-</dl>
-<?php
-    $e = $this->exception->getPrevious();
-    $icount = 0;
-    if ($e) :
-?>
-<hr/>
-<h2>Previous exceptions:</h2>
-<ul class="unstyled">
-    <?php while($e) : ?>
-    <li>
-        <h3><?= get_class($e) ?></h3>
+        <h2>Additional information:</h2>
+        <h3><?php echo get_class($this->exception) ?></h3>
         <dl>
             <dt>File:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $e->getFile() ?>:<?= $e->getLine() ?></pre>
+                <pre><?php echo $this->exception->getFile() ?>:<?php echo $this->exception->getLine() ?></pre>
             </dd>
             <dt>Message:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $e->getMessage() ?></pre>
+                <pre><?php echo $this->escapeHtml($this->exception->getMessage()) ?></pre>
             </dd>
             <dt>Stack trace:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $e->getTraceAsString() ?></pre>
+                <pre><?php echo $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
             </dd>
         </dl>
-    </li>
-    <?php
-        $e = $e->getPrevious();
-        $icount += 1;
-        if ($icount >=50) {
-            echo "<li>There may be more exceptions, but we have no enough memory to proccess it.</li>";
-            break;
-        }
-        endwhile;
-    ?>
-</ul>
-<?php endif; ?>
 
-<?php else: ?>
+        <?php if ($ex = $this->exception->getPrevious()): ?>
+            <hr/>
 
-<h3>No Exception available</h3>
-
-<?php endif ?>
-
+            <h2>Previous exceptions:</h2>
+            <ul class="list-unstyled">
+                <?php $icount = 0; ?>
+                <?php while ($ex): ?>
+                    <li>
+                        <h3><?php echo get_class($ex) ?></h3>
+                        <dl>
+                            <dt>File:</dt>
+                            <dd>
+                                <pre><?php echo $ex->getFile() ?>:<?php echo $ex->getLine() ?></pre>
+                            </dd>
+                            <dt>Message:</dt>
+                            <dd>
+                                <pre><?php echo $this->escapeHtml($ex->getMessage()) ?></pre>
+                            </dd>
+                            <dt>Stack trace:</dt>
+                            <dd>
+                                <pre><?php echo $this->escapeHtml($ex->getTraceAsString()) ?></pre>
+                            </dd>
+                        </dl>
+                    </li>
+                    <?php
+                    $ex = $ex->getPrevious();
+                    if (++$icount >= 50) {
+                        echo '<li>There may be more exceptions, but we have no enough memory to proccess it.</li>';
+                        break;
+                    }
+                    ?>
+                <?php endwhile ?>
+            </ul>
+        <?php endif ?>
+    <?php else: ?>
+        <h3>No Exception available</h3>
+    <?php endif ?>
 <?php endif ?>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -1,68 +1,62 @@
 <h1>An error occurred</h1>
-<h2><?= $this->message ?></h2>
+<h2><?php echo $this->message ?></h2>
 
 <?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
+    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)): ?>
+        <hr/>
 
-<?php if(isset($this->exception) && ($this->exception instanceof Exception || $this->exception instanceof Error)): ?>
-<hr/>
-<h2>Additional information:</h2>
-<h3><?= get_class($this->exception) ?></h3>
-<dl>
-    <dt>File:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->exception->getFile() ?>:<?= $this->exception->getLine() ?></pre>
-    </dd>
-    <dt>Message:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->escapeHtml($this->exception->getMessage()) ?></pre>
-    </dd>
-    <dt>Stack trace:</dt>
-    <dd>
-        <pre class="prettyprint linenums"><?= $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
-    </dd>
-</dl>
-<?php
-    $e = $this->exception->getPrevious();
-    $icount = 0;
-    if ($e) :
-?>
-<hr/>
-<h2>Previous exceptions:</h2>
-<ul class="unstyled">
-    <?php while($e) : ?>
-    <li>
-        <h3><?= get_class($e) ?></h3>
+        <h2>Additional information:</h2>
+        <h3><?php echo get_class($this->exception) ?></h3>
         <dl>
             <dt>File:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $e->getFile() ?>:<?= $e->getLine() ?></pre>
+                <pre><?php echo $this->exception->getFile() ?>:<?php echo $this->exception->getLine() ?></pre>
             </dd>
             <dt>Message:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $this->escapeHtml($e->getMessage()) ?></pre>
+                <pre><?php echo $this->escapeHtml($this->exception->getMessage()) ?></pre>
             </dd>
             <dt>Stack trace:</dt>
             <dd>
-                <pre class="prettyprint linenums"><?= $this->escapeHtml($e->getTraceAsString()) ?></pre>
+                <pre><?php echo $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
             </dd>
         </dl>
-    </li>
-    <?php
-        $e = $e->getPrevious();
-        $icount += 1;
-        if ($icount >= 50) {
-            echo "<li>There may be more exceptions, but we have no enough memory to proccess it.</li>";
-            break;
-        }
-        endwhile;
-    ?>
-</ul>
-<?php endif; ?>
 
-<?php else: ?>
+        <?php if ($ex = $this->exception->getPrevious()): ?>
+            <hr/>
 
-<h3>No Exception available</h3>
-
-<?php endif ?>
-
+            <h2>Previous exceptions:</h2>
+            <ul class="list-unstyled">
+                <?php $icount = 0; ?>
+                <?php while ($ex): ?>
+                    <li>
+                        <h3><?php echo get_class($ex) ?></h3>
+                        <dl>
+                            <dt>File:</dt>
+                            <dd>
+                                <pre><?php echo $ex->getFile() ?>:<?php echo $ex->getLine() ?></pre>
+                            </dd>
+                            <dt>Message:</dt>
+                            <dd>
+                                <pre><?php echo $this->escapeHtml($ex->getMessage()) ?></pre>
+                            </dd>
+                            <dt>Stack trace:</dt>
+                            <dd>
+                                <pre><?php echo $this->escapeHtml($ex->getTraceAsString()) ?></pre>
+                            </dd>
+                        </dl>
+                    </li>
+                    <?php
+                    $ex = $ex->getPrevious();
+                    if (++$icount >= 50) {
+                        echo '<li>There may be more exceptions, but we have no enough memory to proccess it.</li>';
+                        break;
+                    }
+                    ?>
+                <?php endwhile ?>
+            </ul>
+        <?php endif ?>
+    <?php else: ?>
+        <h3>No Exception available</h3>
+    <?php endif ?>
 <?php endif ?>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -1,8 +1,8 @@
 <h1>An error occurred</h1>
 <h2><?= $this->message ?></h2>
 
-<?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
-    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)): ?>
+<?php if (isset($this->display_exceptions) && $this->display_exceptions) : ?>
+    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
         <hr/>
 
         <h2>Additional information:</h2>
@@ -22,13 +22,13 @@
             </dd>
         </dl>
 
-        <?php if ($ex = $this->exception->getPrevious()): ?>
+        <?php if ($ex = $this->exception->getPrevious()) : ?>
             <hr/>
 
             <h2>Previous exceptions:</h2>
             <ul class="list-unstyled">
                 <?php $icount = 0; ?>
-                <?php while ($ex): ?>
+                <?php while ($ex) : ?>
                     <li>
                         <h3><?= get_class($ex) ?></h3>
                         <dl>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -1,24 +1,24 @@
 <h1>An error occurred</h1>
-<h2><?php echo $this->message ?></h2>
+<h2><?= $this->message ?></h2>
 
 <?php if (isset($this->display_exceptions) && $this->display_exceptions): ?>
     <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)): ?>
         <hr/>
 
         <h2>Additional information:</h2>
-        <h3><?php echo get_class($this->exception) ?></h3>
+        <h3><?= get_class($this->exception) ?></h3>
         <dl>
             <dt>File:</dt>
             <dd>
-                <pre><?php echo $this->exception->getFile() ?>:<?php echo $this->exception->getLine() ?></pre>
+                <pre><?= $this->exception->getFile() ?>:<?= $this->exception->getLine() ?></pre>
             </dd>
             <dt>Message:</dt>
             <dd>
-                <pre><?php echo $this->escapeHtml($this->exception->getMessage()) ?></pre>
+                <pre><?= $this->escapeHtml($this->exception->getMessage()) ?></pre>
             </dd>
             <dt>Stack trace:</dt>
             <dd>
-                <pre><?php echo $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
+                <pre><?= $this->escapeHtml($this->exception->getTraceAsString()) ?></pre>
             </dd>
         </dl>
 
@@ -30,19 +30,19 @@
                 <?php $icount = 0; ?>
                 <?php while ($ex): ?>
                     <li>
-                        <h3><?php echo get_class($ex) ?></h3>
+                        <h3><?= get_class($ex) ?></h3>
                         <dl>
                             <dt>File:</dt>
                             <dd>
-                                <pre><?php echo $ex->getFile() ?>:<?php echo $ex->getLine() ?></pre>
+                                <pre><?= $ex->getFile() ?>:<?= $ex->getLine() ?></pre>
                             </dd>
                             <dt>Message:</dt>
                             <dd>
-                                <pre><?php echo $this->escapeHtml($ex->getMessage()) ?></pre>
+                                <pre><?= $this->escapeHtml($ex->getMessage()) ?></pre>
                             </dd>
                             <dt>Stack trace:</dt>
                             <dd>
-                                <pre><?php echo $this->escapeHtml($ex->getTraceAsString()) ?></pre>
+                                <pre><?= $this->escapeHtml($ex->getTraceAsString()) ?></pre>
                             </dd>
                         </dl>
                     </li>


### PR DESCRIPTION
Related to https://github.com/zendframework/ZendSkeletonApplication/issues/342

* fixed indents and spacing
* converted all `<?php echo` statements to `<?=`
* removed redundant classes in error views
* `$ex` for exception variable instead of `$e`
* used constant instead of strings
* added `escapeHtml` on error message and trace

Any suggestions would be appreciated.