### PR TITLE
Provide development mode - class

### DIFF
--- a/bin/development-mode
+++ b/bin/development-mode
@@ -1,0 +1,235 @@
+#!/usr/bin/env php
+<?php
+/**
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+const CONFIG_CACHE_BASE = 'module-config-cache';
+
+$help = <<< EOH
+Enable/Disable development mode.
+
+Usage:
+
+development-mode [-h|--help] disable|enable
+
+--help|-h                    Print this usage message.
+disable                      Disable development mode.
+enable                       Enable development mode
+                             (do not use in production).
+
+To enable development mode, the following file MUST exist:
+
+- config/development.config.php.dist; this file will be copied to
+  config/development.config.php
+
+Optionally:
+
+- config/autoload/development.local.php.dist; this file will be copied to
+  config/autoload/development.local.php
+
+When disabling development mode:
+
+- config/development.config.php will be removed if it exists
+- config/autoload/development.local.php will be removed if it exists
+
+Additionally, both when disabling and enabling development mode, the
+script will remove the file cache/module-config-cache.php (or the file
+specified by the combination of the module_listener_options.cache_dir
+and module_listener_options.config_cache_key options).
+EOH;
+
+// Called without arguments
+if ($argc < 2) {
+    fwrite(STDERR, 'No arguments provided.' . PHP_EOL . PHP_EOL);
+    fwrite(STDERR, $help . PHP_EOL);
+    exit(1);
+}
+
+// Requested help
+if (in_array($argv[1], ['-h', '--help'], true)) {
+    echo $help, PHP_EOL;
+    exit(0);
+}
+
+if (! in_array($argv[1], ['disable', 'enable'], true)) {
+    fwrite(STDERR, 'Unrecognized argument.' . PHP_EOL . PHP_EOL);
+    fwrite(STDERR, $help . PHP_EOL);
+    exit(1);
+}
+
+$action = $argv[1];
+$return = $action();
+exit((int) $return);
+
+/**
+ * Disable development mode
+ *
+ * @return int
+ */
+function disable()
+{
+    if (! file_exists('config/development.config.php')) {
+        // nothing to do
+        echo "Development mode was already disabled.", PHP_EOL;
+        return 0;
+    }
+
+    if (file_exists('config/autoload/development.local.php')) {
+        // optional application config override
+        unlink('config/autoload/development.local.php');
+    }
+
+    unlink('config/development.config.php');
+
+    removeConfigCacheFile(getConfigCacheFile());
+
+    echo "Development mode is now disabled.", PHP_EOL;
+    return 0;
+}
+
+/**
+ * Enable development mode
+ *
+ * @return int
+ */
+function enable()
+{
+    if (file_exists('config/development.config.php')) {
+        // nothing to do
+        echo "Already in development mode!", PHP_EOL;
+        return 0;
+    }
+
+    if (! file_exists('config/development.config.php.dist')) {
+        fwrite(
+            STDERR,
+            "MISSING \"config/development.config.php.dist\". Could not switch to development mode!" . PHP_EOL
+        );
+        return 1;
+    }
+
+    copy('config/development.config.php.dist', 'config/development.config.php');
+
+    if (file_exists('config/autoload/development.local.php.dist')) {
+        // optional application config override
+        copy('config/autoload/development.local.php.dist', 'config/autoload/development.local.php');
+    }
+
+    removeConfigCacheFile(getConfigCacheFile());
+
+    echo 'You are now in development mode.', PHP_EOL;
+    return 0;
+}
+
+/**
+ * Removes the application configuration cache file, if present.
+ */
+function removeConfigCacheFile($configCacheFile)
+{
+    if ($configCacheFile && file_exists($configCacheFile)) {
+        unlink($configCacheFile);
+    }
+}
+
+/**
+ * Retrieve the config cache file, if any.
+ *
+ * @return false|string
+ */
+function getConfigCacheFile()
+{
+    $configCacheDir = getConfigCacheDir();
+    $configCacheKey = getConfigCacheKey();
+
+    if (empty($configCacheDir)) {
+        return false;
+    }
+
+    $path = sprintf('%s/%s.', $configCacheDir, CONFIG_CACHE_BASE);
+
+    if (! empty($configCacheKey)) {
+        $path .= $configCacheKey . '.';
+    }
+
+    return $path . 'php';
+}
+
+/**
+ * Return the configured configuration cache directory, if any.
+ *
+ * @return null|string
+ */
+function getConfigCacheDir()
+{
+    static $dir;
+
+    if ($dir) {
+        return $dir;
+    }
+
+    $config = getApplicationConfig();
+    if (isset($config['module_listener_options']['cache_dir'])
+        && ! empty($config['module_listener_options']['cache_dir'])
+    ) {
+        $dir = $config['module_listener_options']['cache_dir'];
+    }
+
+    return $dir;
+}
+
+/**
+ * Return the configured configuration cache key, if any.
+ *
+ * @return null|string
+ */
+function getConfigCacheKey()
+{
+    static $key;
+
+    if ($key) {
+        return $key;
+    }
+
+    $config = getApplicationConfig();
+    if (isset($config['module_listener_options']['config_cache_key'])
+        && ! empty($config['module_listener_options']['config_cache_key'])
+    ) {
+        $key = $config['module_listener_options']['config_cache_key'];
+    }
+
+    return $key;
+}
+
+/**
+ * Return the application configuration.
+ *
+ * Memoizes the discovered configuration so subsequent calls can re-use the
+ * value.
+ *
+ * Exits with status code 2 if unable to find the configuration.
+ *
+ * @return array
+ */
+function getApplicationConfig()
+{
+    static $config;
+
+    if ($config) {
+        return $config;
+    }
+
+    if (! file_exists('config/application.config.php')) {
+        fwrite(
+            STDERR,
+            'Cannot locate config/application.config.php; are you in the' . PHP_EOL
+            . 'application root, and is this a zendframework application?' . PHP_EOL
+        );
+        exit(1);
+    }
+
+    $config = include 'config/application.config.php';
+    return $config;
+}

--- a/bin/development-mode
+++ b/bin/development-mode
@@ -73,7 +73,7 @@ function disable()
 {
     if (! file_exists('config/development.config.php')) {
         // nothing to do
-        echo "Development mode was already disabled.", PHP_EOL;
+        echo 'Development mode was already disabled.', PHP_EOL;
         return 0;
     }
 
@@ -86,7 +86,7 @@ function disable()
 
     removeConfigCacheFile(getConfigCacheFile());
 
-    echo "Development mode is now disabled.", PHP_EOL;
+    echo 'Development mode is now disabled.', PHP_EOL;
     return 0;
 }
 
@@ -99,14 +99,14 @@ function enable()
 {
     if (file_exists('config/development.config.php')) {
         // nothing to do
-        echo "Already in development mode!", PHP_EOL;
+        echo 'Already in development mode!', PHP_EOL;
         return 0;
     }
 
     if (! file_exists('config/development.config.php.dist')) {
         fwrite(
             STDERR,
-            "MISSING \"config/development.config.php.dist\". Could not switch to development mode!" . PHP_EOL
+            'MISSING "config/development.config.php.dist". Could not switch to development mode!' . PHP_EOL
         );
         return 1;
     }

--- a/bin/development-mode
+++ b/bin/development-mode
@@ -1,14 +1,20 @@
 #!/usr/bin/env php
 <?php
+
 /**
  * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+class DevelopmentMode
+{
+    const CONFIG_CACHE_BASE = 'module-config-cache';
 
-const CONFIG_CACHE_BASE = 'module-config-cache';
+    const APP_CONFIG_FILE = 'config/application.config.php';
 
-$help = <<< EOH
+    private $config;
+
+    private $help = <<< EOH
 Enable/Disable development mode.
 
 Usage:
@@ -41,195 +47,174 @@ specified by the combination of the module_listener_options.cache_dir
 and module_listener_options.config_cache_key options).
 EOH;
 
-// Called without arguments
-if ($argc < 2) {
-    fwrite(STDERR, 'No arguments provided.' . PHP_EOL . PHP_EOL);
-    fwrite(STDERR, $help . PHP_EOL);
-    exit(1);
+    public function __construct($argc, array $argv)
+    {
+        // Called without arguments
+        if ($argc < 2) {
+            $this->response(1, 'No arguments provided.' . PHP_EOL . PHP_EOL . $this->help);
+        }
+
+        // Requested help
+        if (in_array($argv[1], ['-h', '--help'], true)) {
+            $this->response(0, $this->help);
+        }
+
+        if (!in_array($argv[1], ['disable', 'enable'], true)) {
+            $this->response(1, 'Unrecognized argument.' . PHP_EOL . PHP_EOL . $this->help);
+        }
+
+        $action = $argv[1];
+        $this->$action();
+    }
+
+    protected function response($code, $text = null)
+    {
+        if ($text) {
+            if ($code != 0) {
+                fwrite(STDERR, $text . PHP_EOL);
+            } else {
+                echo $text . PHP_EOL;
+            }
+        }
+
+        exit($code);
+    }
+
+    /**
+     * Disable development mode
+     */
+    protected function disable()
+    {
+        if (!file_exists('config/development.config.php')) {
+            // nothing to do
+            $this->response(0, 'Development mode was already disabled.');
+        }
+
+        if (file_exists('config/autoload/development.local.php')) {
+            // optional application config override
+            unlink('config/autoload/development.local.php');
+        }
+
+        unlink('config/development.config.php');
+
+        $this->removeConfigCacheFile();
+
+        $this->response(0, 'Development mode is now disabled.');
+    }
+
+    /**
+     * Enable development mode
+     */
+    protected function enable()
+    {
+        if (file_exists('config/development.config.php')) {
+            // nothing to do
+            $this->response(0, 'Already in development mode!');
+        }
+
+        if (!file_exists('config/development.config.php.dist')) {
+            $this->response(1, 'MISSING "config/development.config.php.dist". Could not switch to development mode!');
+        }
+
+        copy('config/development.config.php.dist', 'config/development.config.php');
+
+        if (file_exists('config/autoload/development.local.php.dist')) {
+            // optional application config override
+            copy('config/autoload/development.local.php.dist', 'config/autoload/development.local.php');
+        }
+
+        $this->removeConfigCacheFile();
+
+        $this->response(0, 'You are now in development mode.');
+    }
+
+    /**
+     * Removes the application configuration cache file, if present.
+     */
+    protected function removeConfigCacheFile()
+    {
+        $configCacheFile = $this->getConfigCacheFile();
+
+        if ($configCacheFile && file_exists($configCacheFile)) {
+            unlink($configCacheFile);
+        }
+    }
+
+    /**
+     * Retrieve the config cache file, if any.
+     *
+     * @return false|string
+     */
+    protected function getConfigCacheFile()
+    {
+        if (!$configCacheDir = $this->getConfigCacheDir()) {
+            return false;
+        }
+
+        $path = sprintf('%s/%s.', $configCacheDir, self::CONFIG_CACHE_BASE);
+
+        if ($configCacheKey = $this->getConfigCacheKey()) {
+            $path .= $configCacheKey . '.';
+        }
+
+        return $path . 'php';
+    }
+
+    /**
+     * Return the configured configuration cache directory, if any.
+     *
+     * @return null|string
+     */
+    protected function getConfigCacheDir()
+    {
+        $config = $this->getApplicationConfig();
+        if (!empty($config['module_listener_options']['cache_dir'])) {
+            return $config['module_listener_options']['cache_dir'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the configured configuration cache key, if any.
+     *
+     * @return null|string
+     */
+    protected function getConfigCacheKey()
+    {
+        $config = $this->getApplicationConfig();
+        if (!empty($config['module_listener_options']['config_cache_key'])) {
+            return $config['module_listener_options']['config_cache_key'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the application configuration.
+     *
+     * Memorizes the discovered configuration so subsequent calls can re-use the value.
+     *
+     * Exits with status code 1 if unable to find the configuration.
+     *
+     * @return array
+     */
+    protected function getApplicationConfig()
+    {
+        if (!$this->config) {
+            if (!file_exists(self::APP_CONFIG_FILE)) {
+                $this->response(
+                    1,
+                    'Cannot locate ' . self::APP_CONFIG_FILE . '; are you in the' . PHP_EOL
+                    . 'application root, and is this a ZendFramework application?'
+                );
+            }
+
+            $this->config = include self::APP_CONFIG_FILE;
+        }
+
+        return $this->config;
+    }
 }
 
-// Requested help
-if (in_array($argv[1], ['-h', '--help'], true)) {
-    echo $help, PHP_EOL;
-    exit(0);
-}
-
-if (! in_array($argv[1], ['disable', 'enable'], true)) {
-    fwrite(STDERR, 'Unrecognized argument.' . PHP_EOL . PHP_EOL);
-    fwrite(STDERR, $help . PHP_EOL);
-    exit(1);
-}
-
-$action = $argv[1];
-$return = $action();
-exit((int) $return);
-
-/**
- * Disable development mode
- *
- * @return int
- */
-function disable()
-{
-    if (! file_exists('config/development.config.php')) {
-        // nothing to do
-        echo 'Development mode was already disabled.', PHP_EOL;
-        return 0;
-    }
-
-    if (file_exists('config/autoload/development.local.php')) {
-        // optional application config override
-        unlink('config/autoload/development.local.php');
-    }
-
-    unlink('config/development.config.php');
-
-    removeConfigCacheFile(getConfigCacheFile());
-
-    echo 'Development mode is now disabled.', PHP_EOL;
-    return 0;
-}
-
-/**
- * Enable development mode
- *
- * @return int
- */
-function enable()
-{
-    if (file_exists('config/development.config.php')) {
-        // nothing to do
-        echo 'Already in development mode!', PHP_EOL;
-        return 0;
-    }
-
-    if (! file_exists('config/development.config.php.dist')) {
-        fwrite(
-            STDERR,
-            'MISSING "config/development.config.php.dist". Could not switch to development mode!' . PHP_EOL
-        );
-        return 1;
-    }
-
-    copy('config/development.config.php.dist', 'config/development.config.php');
-
-    if (file_exists('config/autoload/development.local.php.dist')) {
-        // optional application config override
-        copy('config/autoload/development.local.php.dist', 'config/autoload/development.local.php');
-    }
-
-    removeConfigCacheFile(getConfigCacheFile());
-
-    echo 'You are now in development mode.', PHP_EOL;
-    return 0;
-}
-
-/**
- * Removes the application configuration cache file, if present.
- */
-function removeConfigCacheFile($configCacheFile)
-{
-    if ($configCacheFile && file_exists($configCacheFile)) {
-        unlink($configCacheFile);
-    }
-}
-
-/**
- * Retrieve the config cache file, if any.
- *
- * @return false|string
- */
-function getConfigCacheFile()
-{
-    $configCacheDir = getConfigCacheDir();
-    $configCacheKey = getConfigCacheKey();
-
-    if (empty($configCacheDir)) {
-        return false;
-    }
-
-    $path = sprintf('%s/%s.', $configCacheDir, CONFIG_CACHE_BASE);
-
-    if (! empty($configCacheKey)) {
-        $path .= $configCacheKey . '.';
-    }
-
-    return $path . 'php';
-}
-
-/**
- * Return the configured configuration cache directory, if any.
- *
- * @return null|string
- */
-function getConfigCacheDir()
-{
-    static $dir;
-
-    if ($dir) {
-        return $dir;
-    }
-
-    $config = getApplicationConfig();
-    if (isset($config['module_listener_options']['cache_dir'])
-        && ! empty($config['module_listener_options']['cache_dir'])
-    ) {
-        $dir = $config['module_listener_options']['cache_dir'];
-    }
-
-    return $dir;
-}
-
-/**
- * Return the configured configuration cache key, if any.
- *
- * @return null|string
- */
-function getConfigCacheKey()
-{
-    static $key;
-
-    if ($key) {
-        return $key;
-    }
-
-    $config = getApplicationConfig();
-    if (isset($config['module_listener_options']['config_cache_key'])
-        && ! empty($config['module_listener_options']['config_cache_key'])
-    ) {
-        $key = $config['module_listener_options']['config_cache_key'];
-    }
-
-    return $key;
-}
-
-/**
- * Return the application configuration.
- *
- * Memoizes the discovered configuration so subsequent calls can re-use the
- * value.
- *
- * Exits with status code 2 if unable to find the configuration.
- *
- * @return array
- */
-function getApplicationConfig()
-{
-    static $config;
-
-    if ($config) {
-        return $config;
-    }
-
-    if (! file_exists('config/application.config.php')) {
-        fwrite(
-            STDERR,
-            'Cannot locate config/application.config.php; are you in the' . PHP_EOL
-            . 'application root, and is this a zendframework application?' . PHP_EOL
-        );
-        exit(1);
-    }
-
-    $config = include 'config/application.config.php';
-    return $config;
-}
+new DevelopmentMode($argc, $argv);

--- a/config/application.config.php
+++ b/config/application.config.php
@@ -6,12 +6,8 @@
  * @see http://framework.zend.com/manual/current/en/tutorials/config.advanced.html#environment-specific-application-configuration
  */
 return [
-    // This should be an array of module namespaces used in the application.
-    'modules' => [
-        'Zend\Router',
-        'Zend\Validator',
-        'Application',
-    ],
+    // Retrieve list of modules used in this application.
+    'modules' => require __DIR__ . '/modules.config.php',
 
     // These are various options for the listeners attached to the ModuleManager
     'module_listener_options' => [

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+return [
+    // Development time modules
+    'modules' => [
+    ],
+    // development time configuration globbing
+    'module_listener_options' => [
+        'config_glob_paths' => ['config/autoload/{,*.}{global,local}-development.php'],
+        'config_cache_enabled' => false,
+        'module_map_cache_enabled' => false,
+    ],
+];

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+/**
+ * List of enabled modules for this application.
+ *
+ * This should be an array of module namespaces used in the application.
+ */
+return [
+    'Zend\Router',
+    'Zend\Validator',
+    'Application',
+];

--- a/public/index.php
+++ b/public/index.php
@@ -32,7 +32,7 @@ if (! class_exists(Application::class)) {
 
 // Retrieve configuration
 $appConfig = require __DIR__ . '/../config/application.config.php';
-if (file_exists(__DIR__ . '/config/development.config.php')) {
+if (file_exists(__DIR__ . '/../config/development.config.php')) {
     $appConfig = ArrayUtils::merge($appConfig, require __DIR__ . '/../config/development.config.php');
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use Zend\Mvc\Application;
+use Zend\Stdlib\ArrayUtils;
 
 /**
  * This makes our life easier when dealing with paths. Everything is relative
@@ -29,5 +30,11 @@ if (! class_exists(Application::class)) {
     );
 }
 
+// Retrieve configuration
+$appConfig = require __DIR__ . '/../config/application.config.php';
+if (file_exists(__DIR__ . '/config/development.config.php')) {
+    $appConfig = ArrayUtils::merge($appConfig, require __DIR__ . '/../config/development.config.php');
+}
+
 // Run the application!
-Application::init(require __DIR__ . '/../config/application.config.php')->run();
+Application::init($appConfig)->run();


### PR DESCRIPTION
@weierophinney please have a look on my improvements - development mode as class.
There are still few things I don't like...

Why I'd prefer this solution?
* everything is encapsulated inside an object
* removed duplications - only one response method returns error and success response depends on response code
* removed  `static` variables
* it could be easier and cleaner parameterized
* code looks more friendly - no procedural code

I don't like:
* `response` method could be better
* maybe it's not clear that calling `response` method stop further execution
* calling on create object (maybe better static method `DevelopmentMode::exec(...)`?)
* maybe we need to pass only `$argv` instead of both: `$argc`, `$argv`

Maybe all of it is matter of preferences. I'd like to fine the most friendly and modern solution. Finally this is gonna be used with ZF3! I think we can improve it a bit 😃 

Thoughts?
