### PR TITLE
Provide an option to install the developer toolbar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,13 @@
     "extra": {
         "zend-skeleton-installer": [
             {
+                "name": "zendframework/zend-developer-tools",
+                "constraint": "^1.1.0",
+                "prompt": "Would you like to install the developer toolbar?",
+                "module": true,
+                "dev": true
+            },
+            {
                 "name": "zendframework/zend-cache",
                 "constraint": "^2.7.1",
                 "prompt": "Would you like to install caching support?",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.6 || ^7.0",
-        "zendframework/zend-component-installer": "^1.0 || ^0.2 || ^1.0.0-dev@dev",
+        "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev",
         "zendframework/zend-skeleton-installer": "^1.0 || ^0.1.2 || ^1.0.0-dev@dev",
         "zendframework/zend-mvc": "^3.0.1",
         "zfcampus/zf-development-mode": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev",
-        "zendframework/zend-skeleton-installer": "^1.0 || ^0.1.2 || ^1.0.0-dev@dev",
+        "zendframework/zend-skeleton-installer": "^1.0 || ^0.1.3 || ^1.0.0-dev@dev",
         "zendframework/zend-mvc": "^3.0.1",
         "zfcampus/zf-development-mode": "^3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9a63c9429f7cd5043cb00de938cf4272",
-    "content-hash": "c891b4668696c36daa3beed6ab0e95b1",
+    "hash": "68b34965034959dd0cc938584e52fc9d",
+    "content-hash": "bbc4cf51d583edd647a090e9419d33ef",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -36,21 +36,21 @@
         },
         {
             "name": "zendframework/zend-component-installer",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-component-installer.git",
-                "reference": "a8364d76ccadf5096b81b27740a618eae7f78a01"
+                "reference": "63149eb094b67a142e014a793853125165870fbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/a8364d76ccadf5096b81b27740a618eae7f78a01",
-                "reference": "a8364d76ccadf5096b81b27740a618eae7f78a01",
+                "url": "https://api.github.com/repos/zendframework/zend-component-installer/zipball/63149eb094b67a142e014a793853125165870fbf",
+                "reference": "63149eb094b67a142e014a793853125165870fbf",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "composer/composer": ">=1.0.0-alpha10",
@@ -76,7 +76,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Composer plugin for automating component registration in zend-mvc and Expressive applications",
-            "time": "2016-06-02 17:44:01"
+            "time": "2016-06-27 21:18:08"
         },
         {
             "name": "zendframework/zend-config",
@@ -568,22 +568,22 @@
         },
         {
             "name": "zendframework/zend-skeleton-installer",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-skeleton-installer.git",
-                "reference": "9922d88ced064898fa58cad947301fd1599f2ae4"
+                "reference": "450b7455de0793fe4329a7f71406cd5cf846b96b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-skeleton-installer/zipball/9922d88ced064898fa58cad947301fd1599f2ae4",
-                "reference": "9922d88ced064898fa58cad947301fd1599f2ae4",
+                "url": "https://api.github.com/repos/zendframework/zend-skeleton-installer/zipball/450b7455de0793fe4329a7f71406cd5cf846b96b",
+                "reference": "450b7455de0793fe4329a7f71406cd5cf846b96b",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.6 || ^7.0",
-                "zendframework/zend-component-installer": "^1.0 || ^0.2 || ^1.0.0-dev@dev"
+                "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev"
             },
             "require-dev": {
                 "composer/composer": "^1.0",
@@ -608,7 +608,7 @@
                 "BSD-3-Clause"
             ],
             "description": "Installer plugin for Zend Framework skeleton application",
-            "time": "2016-06-02 18:33:57"
+            "time": "2016-06-27 21:44:58"
         },
         {
             "name": "zendframework/zend-stdlib",

--- a/config/autoload/zend-developer-tools.local-development.php
+++ b/config/autoload/zend-developer-tools.local-development.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+/**
+ * This is configuration for the ZendDeveloperTools development toolbar.
+ *
+ * It will be enabled when you enable development mode.
+ */
+return [
+    'zenddevelopertools' => [
+        /**
+         * General Profiler settings
+         */
+        'profiler' => [
+            /**
+             * Enables or disables the profiler.
+             *
+             * Expects: bool
+             * Default: true
+             */
+            'enabled' => true,
+
+            /**
+             * Enables or disables the strict mode. If the strict mode is enabled, any error will throw an exception,
+             * otherwise all errors will be added to the report (and shown in the toolbar).
+             *
+             * Expects: bool
+             * Default: true
+             */
+            'strict' => true,
+
+            /**
+             * If enabled, the profiler tries to flush the content before the it starts collecting data. This option
+             * will be ignored if the Toolbar is enabled.
+             *
+             * Note: The flush listener listens to the MvcEvent::EVENT_FINISH event with a priority of -9400. You have
+             * to disable this function if you wish to modify the output with a lower priority.
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'flush_early' => false,
+
+            /**
+             * The cache directory is used in the version check and for every storage type that writes to the disk.
+             * Note: The default value assumes that the current working directory is the application root.
+             *
+             * Expects: string
+             * Default: 'data/cache'
+             */
+            'cache_dir' => 'data/cache',
+
+            /**
+             * If a matches is defined, the profiler will be disabled if the request does not match the pattern.
+             *
+             * Example: 'matcher' => array('ip' => '127.0.0.1')
+             * OR
+             * 'matcher' => array('url' => array('path' => '/admin')
+             * Note: The matcher is not implemented yet!
+             */
+            'matcher' => [],
+
+            /**
+             * Contains a list with all collector the profiler should run. Zend Developer Tools ships with
+             * 'db' (Zend\Db), 'time', 'event', 'memory', 'exception', 'request' and 'mail' (Zend\Mail). If you wish to
+             * disable a default collector, simply set the value to null or false.
+             *
+             * Example: 'collectors' => array('db' => null)
+             * Expects: array
+             */
+            'collectors' => [],
+        ],
+        'events' => [
+            /**
+             * Set to true to enable event-level logging for collectors that will support it. This enables a wildcard
+             * listener onto the shared event manager that will allow profiling of user-defined events as well as the
+             * built-in ZF events.
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'enabled' => true,
+
+            /**
+             * Contains a list with all event-level collectors that should run. Zend Developer Tools ships with 'time'
+             * and 'memory'. If you wish to disable a default collector, simply set the value to null or false.
+             *
+             * Example: 'collectors' => array('memory' => null)
+             * Expects: array
+             */
+            'collectors' => [],
+
+            /**
+             * Contains event identifiers used with the event listener. Zend Developer Tools defaults to listen to all
+             * events. If you wish to disable the default all-inclusive identifier, simply set the value to null or
+             * false.
+             *
+             * Example: 'identifiers' => array('all' => null, 'dispatchable' => 'Zend\Stdlib\DispatchableInterface')
+             * Expects: array
+             */
+            'identifiers' => [],
+        ],
+        /**
+         * General Toolbar settings
+         */
+        'toolbar' => [
+            /**
+             * Enables or disables the Toolbar.
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'enabled' => true,
+
+            /**
+             * If enabled, every empty collector will be hidden.
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'auto_hide' => false,
+
+            /**
+             * The Toolbar position.
+             *
+             * Expects: string ('bottom' or 'top')
+             * Default: bottom
+             */
+            'position' => 'bottom',
+
+            /**
+             * If enabled, the Toolbar will check if your current Zend Framework version is up-to-date.
+             * Note: The check will only occur once every hour.
+             *
+             * Expects: bool
+             * Default: false
+             */
+            'version_check' => false,
+
+            /**
+             * Contains a list with all collector toolbar templates. The name  of the array key must be same as the name
+             * of the collector.
+             *
+             * Example: 'profiler' => array(
+             *  'collectors' => array(
+             *      // My_Collector_Example::getName() -> mycollector
+             *      'MyCollector' => 'My_Collector_Example',
+             *  )
+             * ),
+             * 'toolbar' => array(
+             *  'entries' => array(
+             *      'mycollector' => 'example/toolbar/my-collector',
+             *  )
+             * ),
+             * Expects: array
+             */
+            'entries' => [],
+        ],
+    ],
+];


### PR DESCRIPTION
ZendDeveloperTools has been updated to work with zend-mvc v3, and, as such, is ready for the v3 release. This patch does the following:

- Adds a prompt for installing the developer toolbar, as a development module requirement.
- Updates to zend-component-installer v0.3.0 to ensure that development requirements can be injected properly.
- Provides default configuration for the development toolbar, which will be enabled only when in development mode.