### PR TITLE
module version updated - no longer dev !

### DIFF
--- a/module/Application/src/Module.php
+++ b/module/Application/src/Module.php
@@ -9,7 +9,7 @@ namespace Application;
 
 class Module
 {
-    const VERSION = '3.0.0dev';
+    const VERSION = '3.0.0';
 
     public function getConfig()
     {


### PR DESCRIPTION
The version wasn't updated on release zf3 to 3.0.0, so everyone who start with new ZendSkeletonApplication still see `zf v3.0.0dev` :(