### PR TITLE
Vagrant Ubuntu 16.04 LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ control. (If you want to make the modifications permanent, edit the
 
 ## Using Vagrant
 
-This skeleton includes a `Vagrantfile` based on ubuntu 14.04, and using the
+This skeleton includes a `Vagrantfile` based on ubuntu 16.04, and using the
 ondrej/php PPA to provide PHP 7.0. Start it up using:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ $ vagrant ssh -c 'composer update'
 While running, Vagrant maps your host port 8080 to port 80 on the virtual
 machine; you can visit the site at http://localhost:8080/
 
+> ### Vagrant and VirtualBox
+>
+> The vagrant image is based on ubuntu/xenial64. If you are using VirtualBox as
+> a provider, you will need:
+>
+> - Vagrant 1.8.5 or later
+> - VirtualBox 5.0.26 or later
+
+For vagrant documentation, please refer to [vagrantup.com](https://www.vagrantup.com/)
+
 ## Using docker-compose
 
 This skeleton provides a `docker-compose.yml` for use with

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,15 @@ add-apt-repository ppa:ondrej/php
 apt-get update
 apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
 sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf
+
+echo "<Directory /var/www/public>
+  Options +Indexes +FollowSymLinks
+  DirectoryIndex index.php index.html
+  Order allow,deny
+  Allow from all
+  AllowOverride All
+</Directory>" > /etc/apache2/conf-enabled/htaccess.conf
+
 a2enmod rewrite
 service apache2 restart
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,5 +27,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ["modifyvm", :id, "--name", "ZF Application - Ubuntu 16.04"]
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,8 +11,8 @@ sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-defa
 a2enmod rewrite
 service apache2 restart
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-if ! grep "cd /var/www" /home/vagrant/.profile > /dev/null; then
-    echo "cd /var/www" >> /home/vagrant/.profile
+if ! grep "cd /var/www" /home/ubuntu/.profile > /dev/null; then
+    echo "cd /var/www" >> /home/ubuntu/.profile
 fi
 echo "** [ZF] Run the following command to install dependencies, if you have not already:"
 echo "    vagrant ssh -c 'composer install'"
@@ -20,7 +20,7 @@ echo "** [ZF] Visit http://localhost:8080 in your browser for to view the applic
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/trusty64'
+  config.vm.box = 'ubuntu/xenial64'
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.synced_folder '.', '/var/www'
   config.vm.provision 'shell', inline: @script
@@ -28,5 +28,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "virtualbox" do |vb|
     vb.customize ["modifyvm", :id, "--memory", "1024"]
   end
-
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,25 +4,46 @@
 VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
+# Fix for https://bugs.launchpad.net/ubuntu/+source/livecd-rootfs/+bug/1561250
+if ! grep -q "ubuntu-xenial" /etc/hosts; then
+    echo "127.0.0.1 ubuntu-xenial" >> /etc/hosts
+fi
+
+# Install dependencies
 add-apt-repository ppa:ondrej/php
 apt-get update
 apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
-sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf
 
-echo "<Directory /var/www/public>
-  Options +Indexes +FollowSymLinks
-  DirectoryIndex index.php index.html
-  Order allow,deny
-  Allow from all
-  AllowOverride All
-</Directory>" > /etc/apache2/conf-enabled/htaccess.conf
+# Configure Apache
+echo "<VirtualHost *:80>
+	DocumentRoot /var/www/public
+	AllowEncodedSlashes On
 
+	<Directory /var/www/public>
+		Options +Indexes +FollowSymLinks
+		DirectoryIndex index.php index.html
+		Order allow,deny
+		Allow from all
+		AllowOverride All
+	</Directory>
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>" > /etc/apache2/sites-available/000-default.conf
 a2enmod rewrite
 service apache2 restart
-curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-if ! grep "cd /var/www" /home/ubuntu/.profile > /dev/null; then
+
+if [ -e /usr/local/bin/composer ]; then
+    /usr/local/bin/composer self-update
+else
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+fi
+
+# Reset home directory of vagrant user
+if ! grep -q "cd /var/www" /home/ubuntu/.profile; then
     echo "cd /var/www" >> /home/ubuntu/.profile
 fi
+
 echo "** [ZF] Run the following command to install dependencies, if you have not already:"
 echo "    vagrant ssh -c 'composer install'"
 echo "** [ZF] Visit http://localhost:8080 in your browser for to view the application **"


### PR DESCRIPTION
Vagrant configuration updated to Ubuntu 16.04 LTS (ubuntu/xenial64).

Main user is now `ubuntu` (previously was `vagrant`).
Added also name for the vagrant box: "ZF Application - Ubuntu 16.04".

Log file `ubuntu-xenial-16.04-cloudimg-console.log` is created in the main directory. Not sure if we can disable it somehow. Any ideas?