### PR TITLE
QA Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,31 @@ server {
 ```
 
 Restart the nginx, now you should be ready to go!
+
+## QA Tools
+
+The skeleton does not come with any QA tooling by default, but does ship with
+configuration for each of:
+
+- [phpcs](https://github.com/squizlabs/php_codesniffer)
+- [phpunit](https://phpunit.de)
+
+Additionally, it comes with some basic tests for the shipped
+`Application\Controller\IndexController`.
+
+If you want to add these QA tools, execute the following:
+
+```bash
+$ composer require --dev phpunit/phpunit squizlabs/php_codesniffer zendframework/zend-test
+```
+
+We provide aliases for each of these tools in the Composer configuration:
+
+```bash
+# Run CS checks:
+$ composer cs-check
+# Fix CS errors:
+$ composer cs-fix
+# Run PHPUnit tests:
+$ composer test
+```

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ $ composer create-project -sdev zendframework/skeleton-application path/to/insta
 Once installed, you can test it out immediately using PHP's built-in web server:
 
 ```bash
+$ cd path/to/install
 $ php -S 0.0.0.0:8080 -t public/ public/index.php
+# OR use the composer alias:
+$ composer serve
 ```
 
 This will start the cli-server on port 8080, and bind it to all network
-interfaces.
+interfaces. You can then visit the site at http://localhost:8080/
+- which will bring up Zend Framework welcome page.
 
 **Note:** The built-in CLI server is *for development only*.
 

--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,8 @@
         ]
     },
     "scripts": {
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
         "development-disable": "zf-development-mode disable",
         "development-enable": "zf-development-mode enable",
         "development-status": "zf-development-mode status",

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "development-disable": "zf-development-mode disable",
         "development-enable": "zf-development-mode enable",
         "development-status": "zf-development-mode status",
-        "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php"
+        "serve": "php -S 0.0.0.0:8080 -t public/ public/index.php",
+        "test": "phpunit"
     }
 }

--- a/module/Application/view/error/404.phtml
+++ b/module/Application/view/error/404.phtml
@@ -42,7 +42,8 @@
 <?php endif ?>
 
 <?php if (! empty($this->display_exceptions)) : ?>
-    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
+    <?php if (isset($this->exception)
+        && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
 <hr/>
 
 <h2>Additional information:</h2>

--- a/module/Application/view/error/index.phtml
+++ b/module/Application/view/error/index.phtml
@@ -2,7 +2,8 @@
 <h2><?= $this->message ?></h2>
 
 <?php if (! empty($this->display_exceptions)) : ?>
-    <?php if (isset($this->exception) && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
+    <?php if (isset($this->exception)
+        && ($this->exception instanceof \Exception || $this->exception instanceof \Error)) : ?>
 <hr/>
 
 <h2>Additional information:</h2>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset name="Zend Framework coding standard">
+    <description>Zend Framework coding standard</description>
+
+    <!-- display progress -->
+    <arg value="p"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php,dist,phtml"/>
+
+    <!-- inherit rules from: -->
+    <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.Formatting.SpaceAfterNot"/>
+    <rule ref="Squiz.WhiteSpace.OperatorSpacing">
+        <properties>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
+        <properties>
+            <property name="ignoreBlankLines" value="false"/>
+        </properties>
+    </rule>
+    <rule ref="PSR1.Files.SideEffects">
+        <exclude-pattern>public/index.php</exclude-pattern>
+    </rule>
+
+    <!-- Paths to check -->
+    <file>config</file>
+    <file>module</file>
+    <file>public/index.php</file>
+</ruleset>


### PR DESCRIPTION
As we have it in apigility skeleton I've added CS rules and composer scripts: `cs-check`, `cs-fix`, `test`.
Base test for `Application\Controller\IndexController` and phpunit dist configuration was already there.
Updated notes in README.md about script `composer serve`.

Also added section "QA Tools' into README.md.

Maybe we should add another note in README.md - `zend-test` is one of the optional packages of the installer - hm... or maybe we should change "Running Unit Tests" section, or remove this part at all.