### PR TITLE
Updated .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.vagrant/
 vendor/
-composer.phar
 config/development.config.php
+data/cache/*
+!data/cache/.gitkeep
 phpunit.xml
 ubuntu-xenial-16.04-cloudimg-console.log

--- a/data/cache/.gitignore
+++ b/data/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
The same rules as we have in apigility skeleton.
- added `.vagrant/` directory
- removed `composer.phar`
- `.gitkeep` in `data/cache` instead of `.gitignore` there