### PR TITLE
Vagrant box changed to `bento/ubuntu-16.04`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ config/development.config.php
 data/cache/*
 !data/cache/.gitkeep
 phpunit.xml
-ubuntu-xenial-16.04-cloudimg-console.log

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ control. (If you want to make the modifications permanent, edit the
 
 ## Using Vagrant
 
-This skeleton includes a `Vagrantfile` based on ubuntu 16.04, and using the
-ondrej/php PPA to provide PHP 7.0. Start it up using:
+This skeleton includes a `Vagrantfile` based on ubuntu 16.04 (bento box)
+with configured Apache2 and PHP 7.0. Start it up using:
 
 ```bash
 $ vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,13 +4,7 @@
 VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
-# Fix for https://bugs.launchpad.net/ubuntu/+source/livecd-rootfs/+bug/1561250
-if ! grep -q "ubuntu-xenial" /etc/hosts; then
-    echo "127.0.0.1 ubuntu-xenial" >> /etc/hosts
-fi
-
 # Install dependencies
-add-apt-repository ppa:ondrej/php
 apt-get update
 apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
 
@@ -40,8 +34,8 @@ else
 fi
 
 # Reset home directory of vagrant user
-if ! grep -q "cd /var/www" /home/ubuntu/.profile; then
-    echo "cd /var/www" >> /home/ubuntu/.profile
+if ! grep -q "cd /var/www" /home/vagrant/.profile; then
+    echo "cd /var/www" >> /home/vagrant/.profile
 fi
 
 echo "** [ZF] Run the following command to install dependencies, if you have not already:"
@@ -50,7 +44,7 @@ echo "** [ZF] Visit http://localhost:8080 in your browser for to view the applic
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/xenial64'
+  config.vm.box = 'bento/ubuntu-16.04'
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.synced_folder '.', '/var/www'
   config.vm.provision 'shell', inline: @script


### PR DESCRIPTION
Vagrant box changed to `bento/ubuntu-16.04`.
There are some issues with official canonical boxes:
https://github.com/mitchellh/vagrant/issues/7155#issuecomment-228568200

Please have a look also on issue: #385 

There is also no needed to use ondrej/php PPA anymore, and log file "ubuntu-xenial-16.04-cloudimg-console.log" with this box is not created.
Default user with this box is `vagrant`, not `ubuntu`.

Tested on OSX with Vagrant 1.8.5 + VirtualBox 5.0.26 and 5.1.6.
