### PR TITLE
	Fixed and modernised docker / docker-compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM php:7.0-apache
 
 RUN apt-get update \
- && apt-get install -y git zlib1g-dev \
- && docker-php-ext-install zip \
- && a2enmod rewrite \
- && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/apache2.conf \
- && mv /var/www/html /var/www/public \
- && curl -sS https://getcomposer.org/installer \
-  | php -- --install-dir=/usr/local/bin --filename=composer
+  && apt-get install -y git zlib1g-dev \
+  && docker-php-ext-install zip \
+  && a2enmod rewrite \
+  && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-enabled/000-default.conf \
+  && curl -sS https://getcomposer.org/installer \
+    | php -- --install-dir=/usr/local/bin --filename=composer
 
 WORKDIR /var/www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,18 @@
-zf:
-  build: .
-  dockerfile: Dockerfile
-  ports:
-   - "8080:80"
-  volumes:
-   - .:/var/www
+version: '2'
+
+volumes:
+  cache:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: uid=33
+
+services:
+  zf:
+    build: .
+    ports:
+      - 8080:80
+    volumes:
+      - .:/var/www
+      - cache:/var/www/data/cache


### PR DESCRIPTION
- Switched to docker-compose syntax version: '2'
- Updating docker-compose to provide a tmpfs cache directory that won't sync / pollute local disk
