### PR TITLE
Update composer serve instruction in README to account for default composer timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once installed, you can test it out immediately using PHP's built-in web server:
 $ cd path/to/install
 $ php -S 0.0.0.0:8080 -t public/ public/index.php
 # OR use the composer alias:
-$ composer serve
+$ composer run --timeout 0 serve
 ```
 
 This will start the cli-server on port 8080, and bind it to all network


### PR DESCRIPTION
`composer run --timeout 0 serve` will disable default 5 minutes timeout