### PR TITLE
Fix - Fail to serve with built-in server as instructed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once installed, you can test it out immediately using PHP's built-in web server:
 
 ```bash
 $ cd path/to/install
-$ php -S 0.0.0.0:8080 -t public/ public/index.php
+$ php -S 0.0.0.0:8080 -t public/ index.php
 # OR use the composer alias:
 $ composer run --timeout 0 serve
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Once installed, you can test it out immediately using PHP's built-in web server:
 
 ```bash
 $ cd path/to/install
-$ php -S 0.0.0.0:8080 -t public/ index.php
+$ php -S 0.0.0.0:8080 -t public
 # OR use the composer alias:
 $ composer run --timeout 0 serve
 ```

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
         "development-enable": "zf-development-mode enable",
         "development-status": "zf-development-mode status",
         "post-create-project-cmd": ["@development-enable"],
-        "serve": "php -S 0.0.0.0:8080 -t public/ index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,7 @@
         "development-enable": "zf-development-mode enable",
         "development-status": "zf-development-mode status",
         "post-create-project-cmd": ["@development-enable"],
-        "serve": "php -S 0.0.0.0:8080 -t public public/index.php",
+        "serve": "php -S 0.0.0.0:8080 -t public/ index.php",
         "test": "phpunit"
     }
 }


### PR DESCRIPTION
Error at line 25:
```
$ php -S 0.0.0.0:8080 -t public/ public/index.php
```
Error in logging output:
```
PHP 7.0.28-0ubuntu0.16.04.1 Development Server started at Mon Mar 26 09:42:37 2018
Listening on http://0.0.0.0:8080
Document root is /home/userj/My/repos/ZendFrameworkRibs/ZF3/helloworld/public
Press Ctrl-C to quit.
[Mon Mar 26 09:42:53 2018] PHP Warning:  Unknown: failed to open stream: No such file or directory in Unknown on line 0
[Mon Mar 26 09:42:53 2018] PHP Fatal error:  Unknown: Failed opening required '/home/userj/My/repos/ZendFrameworkRibs/ZF3/helloworld/public/public/index.php' (include_path='.:/usr/share/php') in Unknown on line 0

```