### PR TITLE
Add installer option for phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,9 +96,15 @@
                 "module": true
             },
             {
+                "name": "phpunit/phpunit",
+                "constraint": "^7.5.12 || ^6.5.14 || ^5.7.14",
+                "prompt": "Would you like to install testing support?",
+                "dev": true
+            },
+            {
                 "name": "zendframework/zend-test",
                 "constraint": "^3.0.1",
-                "prompt": "Would you like to install MVC testing support?",
+                "prompt": "Would you like to install MVC testing tools for testing support?",
                 "dev": true
             },
             {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7416b3013f769a912f5c3850e4581629",
+    "content-hash": "2ec0c8035714db56f3a0a5f83836151e",
     "packages": [
         {
             "name": "container-interop/container-interop",


### PR DESCRIPTION
This PR adds an installer option for phpunit/phpunit to avoid implicit dependency via zend-test that can cause incompatibilities on PHPUnit major release update as seen in #443 