### PR TITLE
Fix post-create-project-cmd

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
         "development-status": "zf-development-mode status",
         "post-create-project-cmd": [
             "@development-enable",
-            "php -r '$file = file_get_contents(\".gitignore\"); $file = str_replace(\"composer.lock\", \"\", $file); file_put_contents(\".gitignore\", $file);"
+            "php -r '$file = file_get_contents(\".gitignore\"); $file = str_replace(\"composer.lock\", \"\", $file); file_put_contents(\".gitignore\", $file);'"
         ],
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"


### PR DESCRIPTION
In #448, we added an additional post-create-project-cmd for removing the `composer.lock` entry from the `.gitignore` file. Unfortunately, it was missing a terminating quote in the command string, causing a syntax error.