### PR TITLE
Hotfix: change quoting in composer script to work cross platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
         "development-status": "zf-development-mode status",
         "post-create-project-cmd": [
             "@development-enable",
-            "php -r '$file = file_get_contents(\".gitignore\"); $file = str_replace(\"composer.lock\", \"\", $file); file_put_contents(\".gitignore\", $file);'"
+            "php -r \"$file = file_get_contents('.gitignore'); $file = str_replace('composer.lock', '', $file); file_put_contents('.gitignore', $file);\""
         ],
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"


### PR DESCRIPTION
The issue is present on Windows when using single quotes.

Fix #450