### PR TITLE
Use script for updating .gitignore

### DIFF
--- a/bin/update-gitignore.php
+++ b/bin/update-gitignore.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/ZendSkeletonApplication/blob/master/LICENSE.md New BSD License
+ */
+
+$gitIgnore = sprintf('%s/.gitignore', realpath(dirname(__DIR__)));
+$rules     = file_get_contents($gitIgnore);
+$rules     = preg_replace("#[\r\n]+composer.lock#s", '', $rules);
+file_put_contents($gitIgnore, $rules);
+unlink(__FILE__);

--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
         "development-status": "zf-development-mode status",
         "post-create-project-cmd": [
             "@development-enable",
-            "php -r \"$file = file_get_contents('.gitignore'); $file = str_replace('composer.lock', '', $file); file_put_contents('.gitignore', $file);\""
+            "php bin/update-gitignore.php"
         ],
         "serve": "php -S 0.0.0.0:8080 -t public",
         "test": "phpunit"


### PR DESCRIPTION
Due to quoting issues between different operating systems, the script for removing the `composer.lock` entry from the `.gitignore` file was not working on Linux after a recent update to provide support for Windows. To provide a truly cross-platform way to work, this patch provides a script, `bin/update-gitignore`, which does the work. The `composer.json` entry is updated to call that script, which deletes itself on completion.

Fixes #450